### PR TITLE
Using mysql Pool Cluster for replica load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ module.exports = {
 			database: '{{your-db-tablename}}',
 
       replication: {
+        canRetry: true,
+        removeNodeErrorCount: 5,
+        restoreNodeTimeout: 1000 * 60 * 5,
+        defaultSelector: 'RR', // 'RANDOM' or 'ORDER'
         sources: { 
           readonly: {
             host: '{{replica-1-host}}',

--- a/lib/db.js
+++ b/lib/db.js
@@ -4,9 +4,59 @@
  *
  * @module db
  */
-var mysql = require('mysql');
+var mysql = require('mysql'),
+    errors = require('./errors'),
+    db;
 
-module.exports = {
+db = {
+    /**
+     * Create a ckuster of pools
+     *
+     * @param  {object} config
+     * @return {mySQL.PoolCluster}
+     */
+    createCluster: function (config, master) {
+        var peerNames = Object.keys(config),
+            poolCluster;
+
+        // return undefined if there is no peer config or no master config
+        if (peerNames.length === 0 || !master) {
+            return {
+                getConnection: function (callback) {
+                    callback && callback(errors.REPLICATION_NO_SOURCE);
+                },
+                end: function () {}
+            };
+        }
+
+        // if there are more than one config, we would load balance
+        (peerNames.length > 1) && (poolCluster = mysql.createPoolCluster({
+            restoreNodeTimeout: (1000 * 60)
+        }));
+
+        // at this point, more than one config exists and as such, it needs load balancing
+        peerNames.forEach(function (peerName) {
+            var peerConfig = {
+                user: config[peerName].user,
+                password: config[peerName].password,
+                port: config[peerName].port,
+                database: master.database,
+                pool: true,
+                waitForConnections: true
+            };
+
+            // if pool cluster is not defined, it implies here that only single connection
+            // is needed, so we create one and exit
+            poolCluster ? poolCluster.add(peerName, peerConfig) : (poolCluster = db.createSource(peerConfig));
+        });
+
+        return poolCluster || {
+            getConnection: function (callback) {
+                callback && callback(errors.REPLICATION_NO_SOURCE);
+            },
+            end: function () {}
+        };
+    },
     /**
      * Create db connection source based on configuration parameter provided.
      *
@@ -53,3 +103,5 @@ module.exports = {
         };
     }
 };
+
+module.exports = db;

--- a/lib/db.js
+++ b/lib/db.js
@@ -4,11 +4,26 @@
  *
  * @module db
  */
-var mysql = require('mysql'),
+var has = 'hasOwnProperty', // for syntactic sugar only
+
+    mysql = require('mysql'),
     errors = require('./errors'),
     db;
 
 db = {
+    /**
+     * this source is designed to not return any connection and instead
+     * pass error to callback.
+     *
+     * @type {object}
+     */
+    oneDumbSource: {
+        getConnection: function (callback) {
+            callback && callback(errors.REPLICATION_NO_SOURCE);
+        },
+        end: function () {}
+    },
+
     /**
      * Create a ckuster of pools
      *
@@ -16,46 +31,49 @@ db = {
      * @return {mySQL.PoolCluster}
      */
     createCluster: function (config, master) {
-        var peerNames = Object.keys(config),
+        var peerNames = Object.keys(config.sources),
             poolCluster;
 
         // return undefined if there is no peer config or no master config
         if (peerNames.length === 0 || !master) {
-            return {
-                getConnection: function (callback) {
-                    callback && callback(errors.REPLICATION_NO_SOURCE);
-                },
-                end: function () {}
-            };
+            return db.oneDumbSource;
         }
 
         // if there are more than one config, we would load balance
         (peerNames.length > 1) && (poolCluster = mysql.createPoolCluster({
-            restoreNodeTimeout: (1000 * 60)
+            canRetry: config[has]('canRetry') ? config.canRetry : true,
+            removeNodeErrorCount: config[has]('removeNodeErrorCount') ? config.removeNodeErrorCount : 5,
+            restoreNodeTimeout: config[has]('restoreNodeTimeout') ? config.restoreNodeTimeout : (1000 * 60 * 5),
+            defaultSelector: config[has]('defaultSelector') ? config.defaultSelector : 'RR'
         }));
 
         // at this point, more than one config exists and as such, it needs load balancing
         peerNames.forEach(function (peerName) {
-            var peerConfig = {
-                user: config[peerName].user,
-                password: config[peerName].password,
-                port: config[peerName].port,
-                database: master.database,
-                pool: true,
-                waitForConnections: true
-            };
+            // do not add this peer if it has enabled: false ,arked in config
+            if (config.sources[peerName].enabled === false) {
+                return;
+            }
+
+            var sourceConfig = config.sources[peerName],
+                peerConfig = {
+                    user: sourceConfig.user,
+                    password: sourceConfig.password,
+                    port: sourceConfig.port,
+                    database: master.database,
+                    pool: true,
+                    waitForConnections: true,
+                    multipleStatements: true
+                };
+
+            // allow database name change for debug
+            sourceConfig.hasOwnProperty('_database') && (peerConfig.database = sourceConfig._database);
 
             // if pool cluster is not defined, it implies here that only single connection
             // is needed, so we create one and exit
             poolCluster ? poolCluster.add(peerName, peerConfig) : (poolCluster = db.createSource(peerConfig));
         });
 
-        return poolCluster || {
-            getConnection: function (callback) {
-                callback && callback(errors.REPLICATION_NO_SOURCE);
-            },
-            end: function () {}
-        };
+        return poolCluster || db.oneDumbSource;
     },
     /**
      * Create db connection source based on configuration parameter provided.

--- a/lib/multiplexer.js
+++ b/lib/multiplexer.js
@@ -46,7 +46,7 @@ util.extend(Multiplexer, {
      *
      * @type {object}
      */
-    sources: {},
+    source: db.oneDumbSource,
     /**
      * Stores all connections based on its universal thread id (source + threadId).
      * @private
@@ -60,13 +60,13 @@ util.extend(Multiplexer, {
      * @param  {object} config
      */
     setup: function (config) {
-        if (!config || !config.replication) { return; }
+        if (!(config && config.replication && config.replication.sources)) { return; }
 
         // in case sources exist (almost unlikely, end them)
-        this.source && this.sources.end();
+        this.source && this.source.end();
 
         // create connections for read-replicas and add it to the peering list
-        this.source = db.createCluster(config.replication.sources, config);
+        this.source = db.createCluster(config.replication, config);
     },
 
     /**

--- a/lib/multiplexer.js
+++ b/lib/multiplexer.js
@@ -2,8 +2,6 @@ var FN = 'function',
 
     util = require('./util'),
     db = require('./db'),
-    errors = require('./errors'),
-    Peers = require('weighted-round-robin'),
 
     redeffer, // fn
     Multiplexer; // constructor
@@ -20,7 +18,7 @@ redeffer = function (defer, multiplexer) {
             if (error) { return cb(error); }
 
             defer.constructor.prototype.exec.call(defer, function (err, result) {
-                multiplexer._disconnect();
+                multiplexer._disconnect(threadId);
                 cb && cb(err, util.wrapquery(result, threadId));
             }, threadId);
         });
@@ -48,7 +46,7 @@ util.extend(Multiplexer, {
      *
      * @type {object}
      */
-    sources: new Peers(),
+    sources: {},
     /**
      * Stores all connections based on its universal thread id (source + threadId).
      * @private
@@ -64,26 +62,11 @@ util.extend(Multiplexer, {
     setup: function (config) {
         if (!config || !config.replication) { return; }
 
-        var sources = this.sources; // create copy of config
+        // in case sources exist (almost unlikely, end them)
+        this.source && this.sources.end();
 
         // create connections for read-replicas and add it to the peering list
-        util.each(config.replication.sources, function (subConfig, sourceId) {
-            // mute readonly properties of replica
-            util.extend(subConfig, {
-                adapter: config.adapter,
-                database: config.database,
-                pool: true,
-                waitForConnections: true
-            });
-            !isNaN(subConfig.port) && (subConfig.port = 3306);
-
-            // add source to peer list
-            sources.add({
-                server: sourceId,
-                weight: 1, // all have equal eight
-                pool: db.createSource(subConfig)
-            });
-        });
+        this.source = db.createCluster(config.replication.sources, config);
     },
 
     /**
@@ -101,13 +84,10 @@ util.extend(Multiplexer, {
 
         // execute end on the db. will end pool if pool, or otherwise will execute whatever `end` that has been
         // exposed by db.js
-        this.sources.each(function (source) {
-            try {
-                source.pool.end();
-            }
-            catch (e) { } // nothing to do with error
-        });
-        this.sources.reset();
+        try {
+            this.source && this.source.end();
+        }
+        catch (e) { } // nothing to do with error
     },
 
     /**
@@ -128,18 +108,13 @@ util.extend(Multiplexer.prototype, {
      * @param  {function} callback receives `error`, `threadId`, `connection` as parameter
      */
     _connect: function (callback) {
-        var self = this,
-            source = Multiplexer.sources.get();
+        var self = this;
 
-        if (!source) {
-            return callback(errors.REPLICATION_NO_SOURCE);
-        }
-
-        source.pool.getConnection(function (error, connection) {
+        Multiplexer.source.getConnection(function (error, connection) {
             if (error) { return callback(error); }
 
             // give a unique id to the connection and store it if not already
-            self._threadId = (source.server + connection.threadId);
+            self._threadId = util.uid();
             Multiplexer.connections[self._threadId] = connection;
 
             callback(null, self._threadId, connection);
@@ -148,10 +123,11 @@ util.extend(Multiplexer.prototype, {
 
     /**
      * Release the connection associated with this multiplexer
+     * @param {string} threadId
      */
-    _disconnect: function () {
-        this._threadId && Multiplexer.connections[this._threadId].release();
-        delete Multiplexer.connections[this._threadId];
+    _disconnect: function (threadId) {
+        Multiplexer.connections[threadId] && Multiplexer.connections[threadId].release();
+        delete Multiplexer.connections[threadId];
     },
 
     /**
@@ -179,7 +155,7 @@ util.extend(Multiplexer.prototype, {
 
             // call function of underlying model
             self._model.findOne(criteria, function (err, result) {
-                self._disconnect();
+                self._disconnect(threadId);
                 callback(err, util.wrapquery(result, threadId));
             }, threadId);
         });
@@ -214,7 +190,7 @@ util.extend(Multiplexer.prototype, {
             if (error) { return callback(error); }
 
             self._model.find(criteria, options, function (err, result) {
-                self._disconnect();
+                self._disconnect(threadId);
                 callback(err, util.wrapquery(result, threadId));
             }, threadId);
         });

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   "dependencies": {
     "lodash": "3.5.0",
     "mysql": "2.5.5",
-    "sails-mysql": "0.10.11",
-    "weighted-round-robin": "2.0.2"
+    "sails-mysql": "0.10.11"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
This PR replaces the `weighted-round-robin` module usage to load balance read replicas. Instead, it utilises `mysql.createPoolCluster`.

- It also exposes cluster configuration that can be passed to it.
- uses `uid` instead of thread id for storing connection references
