### PR TITLE
Updated `mediator` class to raise separate errors for invalid model and invalid transactions

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,11 +6,11 @@ var errors,
     key;
 
 errors = {
-    MEDIATOR_INSTANTIATION: 'Mediator is always expected to be instantiated using `new` keyword.',
-    MEDIATOR_INVALID_CONSTRUCTION: 'Invalid transaction parameters forwarded to the Mediator.',
+    MEDIATOR_INVALID_MODEL: 'Invalid model forwarded to transaction.',
+    MEDIATOR_INVALID_TXN: 'Invalid transaction parameters.',
 
     TRANSACTION_NOT_SETUP: 'Transaction.setup() has not been called. Missing ORM registration?',
-    TRANSACTION_CONNECTION_OVERLAP: 'Multiple connections got associated with a single transaction.',
+    TRANSACTION_CONNECTION_OVERLAP: 'Multiple connections got associated with a single transaction. Nasty!',
     TRANSACTION_UNINITIATED: 'Transaction was used without doing Transaction.start();',
 
     REPLICATION_NO_SOURCE: 'Replication source not found'

--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -38,14 +38,13 @@ redeffer = function (defer, id) {
  * @constructor
  */
 Mediator = function (model, transaction) {
-    // do not allow forgetful call to mediator without instantiating it.
-    if (!(this instanceof Mediator)) {
-        throw errors.MEDIATOR_INSTANTIATION;
+    // ensure that a model and transaction has been forwarded to the mediator.
+    if (!model) {
+        throw errors.MEDIATOR_INVALID_MODEL;
     }
 
-    // ensure that a model and transaction has been forwarded to the mediator.
-    if (!model || !transaction || !((typeof transaction.id === FN) && transaction.id())) {
-        throw errors.MEDIATOR_INVALID_CONSTRUCTION;
+    if (!transaction || !((typeof transaction.id === FN) && transaction.id())) {
+        throw errors.MEDIATOR_INVALID_TXN;
     }
 
     // save reference to model and transaction

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -87,6 +87,7 @@ util.extend(Transaction, /** @lends Transaction */ {
         if (this.db) {
             // @todo - emit wrror event instead of console.log
             console.log('Warn: duplicate setup of connection found in Transactions.setup');
+            this.teardown();
         }
 
         // clone the configuration
@@ -218,7 +219,6 @@ util.extend(Transaction.prototype, /** @lends Transaction.prototype */ {
      * @returns {*}
      *
      * @throws {Error} If failed to query the connection to start a transaction
-     * @throws {Error} If query already has a `transactionId` field.
      */
     wrap: function (query) {
         // it is expected that user starts a transaction before acting upon it. but if the user hasn't, we cannot throw


### PR DESCRIPTION
Previously, `new Mediator` would throw a common error for missing model as well as missing transaction parameter. This might create confusion in debugging. As such, separated the messages.

Also, the check for `new` of Mediator is a stupid thing to do. Removed it.

Also, if duplicate setup is done of construction, a teardown is executed. This has to be handled in a better way by using config.identity during setup.