### PR TITLE
Capture error on expired transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ module.exports = {
 			database: '{{your-db-tablename}}',
 
       transactionConnectionLimit: 10,
+      rollbackTransactionOnError: true,
 
       /* this section is needed only if replication feature is required */
       replication: {
@@ -188,6 +189,8 @@ were either stemmed from the same transaction or wrapped (`transaction.wrap(inst
 In cases where you are performing model instance opertaions such as `save`, `destroy`, etc on instances that has been
 stemmed from a `.populate`, transaction might fail. In such scenarios, performing a `transaction.wrap(instance);` before
 doing instance operations should fix such errors.
+
+If you want to selectively intercept errors from this module, compare using `instanceof Transaction.Error`.
 
 
 ## Support for Read Replicas

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,4 +1,5 @@
 var util = require('./util'),
+    errors = require('./errors'),
     _ = require('lodash'),
     arrProtoSlice = Array.prototype.slice,
     Transaction = require('./transactions'),
@@ -111,6 +112,7 @@ util.each({
 
 util.extend(adapter, {
     identity: 'sails-mysql-transactions',
+    Error: errors.TransactionError,
     Transaction: Transaction,
 
     defaults: util.extend(util.clone(adapter), {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -113,6 +113,23 @@ util.extend(adapter, {
     identity: 'sails-mysql-transactions',
     Transaction: Transaction,
 
+    defaults: util.extend(util.clone(adapter), {
+        pool: true,
+        waitForConnections: true,
+        rollbackTransactionOnError: true,
+        transactionConnectionLimit: 5,
+
+        replication: {
+            enabled: false,
+            inheritMaster: true,
+            canRetry: true,
+            removeNodeErrorCount: 5,
+            restoreNodeTimeout: (1000 * 60 * 5),
+            defaultSelector: 'RR',
+            sources: {}
+        }
+    }),
+
     /**
      * Register this adapter when Sails boots up. This additionally initialises the transactional db connection source
      * and then goes on to execute the original adapter registration.

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -3,7 +3,8 @@
  * @module transaction-errors
  */
 var errors,
-    key;
+    key,
+    TransactionError; // constructor
 
 errors = {
     MEDIATOR_INVALID_MODEL: 'Invalid model forwarded to transaction.',
@@ -18,8 +19,23 @@ errors = {
     REPLICATION_NO_SOURCE: 'Replication source not found'
 };
 
+TransactionError = function (message) {
+    if (!(this instanceof TransactionError)) {
+        return new TransactionError(message);
+    }
+    Error.prototype.constructor.apply(this, arguments);
+    arguments.length && (this.message = message);
+    this.name = 'TransactionError';
+};
+
+TransactionError.prototype = new Error();
+TransactionError.prototype.constructor = TransactionError;
+
 for (key in errors) {
-    errors[key] = new Error('sails-mysql-transactions error: ' + errors[key]);
+    errors[key] = new TransactionError('sails-mysql-transactions error: ' + errors[key]);
 }
+
+// store the root error object
+errors.TransactionError = TransactionError;
 
 module.exports = errors;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,6 +12,8 @@ errors = {
     TRANSACTION_NOT_SETUP: 'Transaction.setup() has not been called. Missing ORM registration?',
     TRANSACTION_CONNECTION_OVERLAP: 'Multiple connections got associated with a single transaction. Nasty!',
     TRANSACTION_UNINITIATED: 'Transaction was used without doing Transaction.start();',
+    TRANSACTION_UNINITIATED_COMM: 'Transaction commit failed since transaction has either expired or not started',
+    TRANSACTION_UNINITIATED_ROLL: 'Transaction rollback failed since transaction has either expired or not started',
 
     REPLICATION_NO_SOURCE: 'Replication source not found'
 };

--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -21,10 +21,12 @@ var FN = 'function',
  * @returns {deffer}
  */
 redeffer = function (defer, id) {
-    defer.exec = function (callback) {
+    defer.exec = id ? function (callback) {
         defer.constructor.prototype.exec.call(defer, function (err, result) {
             callback && callback(err, util.wrapquery(result, id));
         }, id);
+    } : function (callback) { // do not allow exec if transaction id is undefined
+        callback && callback(errors.TRANSACTION_UNINITIATED);
     };
     return defer;
 };
@@ -62,46 +64,50 @@ Mediator = function (model, transaction) {
  */
 util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
     create: function (values, callback) {
-        var self = this;
+        var self = this,
+            id = self._transaction.id();
 
         if (typeof callback !== FN) {
-            return redeffer(self._model.create(this._transaction.wrap(values)), self._transaction.id());
+            return redeffer(self._model.create(this._transaction.wrap(values)), id);
         }
 
         // wrap the values with the transaction id before sending to `.create` of model.
         // @todo perhaps tId could be passed on to waterline create via a direct param
-        return self._model.create(this._transaction.wrap(values), function (err, result) {
+        return id ? self._model.create(this._transaction.wrap(values), function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        });
+        }) : callback(errors.TRANSACTION_UNINITIATED);
     },
 
     update: function (criteria, values, callback) {
-        var self = this;
+        var self = this,
+            id = self._transaction.id();
 
         if (typeof callback !== FN) {
-            return redeffer(self._model.update(criteria, self._transaction.wrap(values)), self._transaction.id());
+            return redeffer(self._model.update(criteria, self._transaction.wrap(values)), id);
         }
 
         // inject transaction id in values
         // @todo - is there no other way than injecting to values? what if pass direct to update?
-        return self._model.update(criteria, self._transaction.wrap(values), function (err, result) {
+        return id ? self._model.update(criteria, self._transaction.wrap(values), function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        });
+        }) : callback(errors.TRANSACTION_UNINITIATED);
     },
 
     // @todo - perhaps tId could be passed on to waterline destroy via a direct param
     destroy: function (criteria, callback) {
-        var self = this;
+        var self = this,
+            id = self._transaction.id();
 
         if (typeof callback !== FN) {
-            return redeffer(self._model.destroy(self._transaction.wrap(criteria)), self._transaction.id());
+            return redeffer(self._model.destroy(self._transaction.wrap(criteria)), id);
         }
 
         // we need to inject the transaction id as part of destruction.
         // since in case of destroy we are not expecting a return result, we do not need to wrap them and as such, we
         // do not need to separately treat callback and promise architecture.
         // @todo - check whether model.destroy returns any result. currently assumed not.
-        return self._model.destroy(self._transaction.wrap(criteria), callback);
+        return id ? self._model.destroy(self._transaction.wrap(criteria), callback) :
+            callback(errors.TRANSACTION_UNINITIATED);
     },
 
     findOrCreate: function (criteria, values, callback) {
@@ -113,9 +119,9 @@ util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
         }
 
         // in this case, the model's `findOrCreate` function accepts tId as a parameter.
-        return self._model.findOrCreate(criteria, values, function (err, result) {
+        return id ? self._model.findOrCreate(criteria, values, function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        }, id);
+        }, id) : callback(errors.TRANSACTION_UNINITIATED);
     },
 
     findOne: function (criteria, callback) {
@@ -127,9 +133,9 @@ util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
         }
 
         // in this case, the model's `findOne` function accepts tId as a parameter.
-        return self._model.findOne(criteria, function (err, result) {
+        return id ? self._model.findOne(criteria, function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        }, id);
+        }, id) : callback(errors.TRANSACTION_UNINITIATED);
     },
 
     // @todo trap when criteria is blank
@@ -151,12 +157,12 @@ util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
         }
 
         if (typeof callback !== FN) {
-            return util.redeffer(self._model.find(criteria, options, undefined, id), id);
+            return redeffer(self._model.find(criteria, options, undefined, id), id);
         }
 
-        return self._model.find(criteria, options, function (err, result) {
+        return id ? self._model.find(criteria, options, function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        }, id);
+        }, id) : callback(errors.TRANSACTION_UNINITIATED);
     }
 });
 

--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -45,7 +45,7 @@ Mediator = function (model, transaction) {
         throw errors.MEDIATOR_INVALID_MODEL;
     }
 
-    if (!transaction || !((typeof transaction.id === FN) && transaction.id())) {
+    if (!transaction) {
         throw errors.MEDIATOR_INVALID_TXN;
     }
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -222,16 +222,8 @@ util.extend(Transaction.prototype, /** @lends Transaction.prototype */ {
      *
      * @param {*} query
      * @returns {*}
-     *
-     * @throws {Error} If failed to query the connection to start a transaction
      */
     wrap: function (query) {
-        // it is expected that user starts a transaction before acting upon it. but if the user hasn't, we cannot throw
-        // error. we should raise a warning.
-        if (!this.connection()) {
-            throw errors.TRANSACTION_UNINITIATED;
-        }
-
         return util.wrapquery(query, this.id());
     },
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -107,6 +107,11 @@ util.extend(Transaction, /** @lends Transaction */ {
         });
 
         this.db = db.createSource(config);
+
+        // Save a few configurations
+        this.db && (this.db.transactionConfig = {
+            rollbackOnError: config.rollbackTransactionOnError
+        });
     },
 
     /**
@@ -253,8 +258,11 @@ util.extend(Transaction.prototype, /** @lends Transaction.prototype */ {
                 !error && (error = err);
             }
 
-            if (error) { // if failure to issue commit or release, then rollback
+            // if failure to issue commit or release, then rollback
+            if (error && Transaction.db.transactionConfig.rollbackOnError) {
                 return conn.rollback(function () {
+                    // disassociate the connection from transaction and execute callback
+                    Transaction.disassociateConnection(conn);
                     callback && callback(error);
                 });
             }

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -261,8 +261,8 @@ util.extend(Transaction.prototype, /** @lends Transaction.prototype */ {
 
             // disassociate the connection from transaction and execute callback
             Transaction.disassociateConnection(conn);
-            callback && callback();
-        }) : (callback && callback(errors.TRANSACTION_UNINITIATED));
+            callback && callback(error);
+        }) : (callback && callback(errors.TRANSACTION_UNINITIATED_COMM));
     },
 
     /**
@@ -291,7 +291,7 @@ util.extend(Transaction.prototype, /** @lends Transaction.prototype */ {
             // disassociate the connection from transaction and execute callback
             Transaction.disassociateConnection(conn);
             callback && callback(error);
-        }) : (callback && callback(errors.TRANSACTION_UNINITIATED));
+        }) : (callback && callback(errors.TRANSACTION_UNINITIATED_ROLL));
     },
 
     toString: function () {

--- a/tests/integration/app/config/local.js
+++ b/tests/integration/app/config/local.js
@@ -54,6 +54,7 @@ module.exports = {
       database: 'sails_transactions',
 
       transactionConnectionLimit: 20,
+      rollbackTransactionOnError: false,
 
       replication: {
         enabled: true,


### PR DESCRIPTION
This PR adds two changes

1. New configuration `rollbackTransactionOnError`, when set to false, does not automatically induce rollback upon commit error

2. Now, incorrect usage of an expired (or not restarted) transaction bubbles error to callback instead of throwing it.

3. Adds more error messages to allow easy distinguish between expired transaction errors triggered due to misuse of rollback and commit.