### PR TITLE
Changed all static error objects to run-time error construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ In cases where you are performing model instance opertaions such as `save`, `des
 stemmed from a `.populate`, transaction might fail. In such scenarios, performing a `transaction.wrap(instance);` before
 doing instance operations should fix such errors.
 
-If you want to selectively intercept errors from this module, compare using `instanceof Transaction.Error`.
+If you want to selectively intercept errors from this module, compare using `instanceof Transaction.AdapterError`.
 
 
 ## Support for Read Replicas

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,5 +1,5 @@
 var util = require('./util'),
-    errors = require('./errors'),
+    AdapterError = require('./errors'),
     _ = require('lodash'),
     arrProtoSlice = Array.prototype.slice,
     Transaction = require('./transactions'),
@@ -112,7 +112,7 @@ util.each({
 
 util.extend(adapter, {
     identity: 'sails-mysql-transactions',
-    Error: errors.TransactionError,
+    AdapterError: AdapterError,
     Transaction: Transaction,
 
     defaults: util.extend(util.clone(adapter), {

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,7 +5,7 @@
  * @module db
  */
 var mysql = require('mysql'),
-    errors = require('./errors'),
+    AdapterError = require('./errors'),
     db;
 
 db = {
@@ -17,7 +17,7 @@ db = {
      */
     oneDumbSource: {
         getConnection: function (callback) {
-            callback && callback(errors.REPLICATION_NO_SOURCE);
+            callback && callback(new AdapterError(AdapterError.REPLICATION_NO_SOURCE));
         },
         end: function () {}
     },

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,11 +2,25 @@
  * This file contains all error messages intended to be used by sails-mysql-transactions
  * @module transaction-errors
  */
-var errors,
-    key,
-    TransactionError; // constructor
+var util = require('./util'),
+    AdapterError; // constructor
+/**
+ * @constructor
+ * @inherits Error
+ */
+AdapterError = function (message) {
+    if (!(this instanceof AdapterError)) {
+        return new AdapterError(message);
+    }
+    Error.captureStackTrace(this, this.constructor);
+    arguments.length && (this.message = message);
+    this.name = 'AdapterError';
+};
 
-errors = {
+AdapterError.prototype = new Error();
+AdapterError.prototype.constructor = AdapterError;
+
+util.extend(AdapterError, {
     MEDIATOR_INVALID_MODEL: 'Invalid model forwarded to transaction.',
     MEDIATOR_INVALID_TXN: 'Invalid transaction parameters.',
 
@@ -17,25 +31,6 @@ errors = {
     TRANSACTION_UNINITIATED_ROLL: 'Transaction rollback failed since transaction has either expired or not started',
 
     REPLICATION_NO_SOURCE: 'Replication source not found'
-};
+});
 
-TransactionError = function (message) {
-    if (!(this instanceof TransactionError)) {
-        return new TransactionError(message);
-    }
-    Error.prototype.constructor.apply(this, arguments);
-    arguments.length && (this.message = message);
-    this.name = 'TransactionError';
-};
-
-TransactionError.prototype = new Error();
-TransactionError.prototype.constructor = TransactionError;
-
-for (key in errors) {
-    errors[key] = new TransactionError('sails-mysql-transactions error: ' + errors[key]);
-}
-
-// store the root error object
-errors.TransactionError = TransactionError;
-
-module.exports = errors;
+module.exports = AdapterError;

--- a/lib/mediator.js
+++ b/lib/mediator.js
@@ -7,7 +7,7 @@
  */
 var FN = 'function',
     util = require('./util'),
-    errors = require('./errors'),
+    AdapterError = require('./errors'),
 
     redeffer, // fn
     Mediator; // constructor
@@ -26,7 +26,7 @@ redeffer = function (defer, id) {
             callback && callback(err, util.wrapquery(result, id));
         }, id);
     } : function (callback) { // do not allow exec if transaction id is undefined
-        callback && callback(errors.TRANSACTION_UNINITIATED);
+        callback && callback(new AdapterError(AdapterError.TRANSACTION_UNINITIATED));
     };
     return defer;
 };
@@ -42,11 +42,11 @@ redeffer = function (defer, id) {
 Mediator = function (model, transaction) {
     // ensure that a model and transaction has been forwarded to the mediator.
     if (!model) {
-        throw errors.MEDIATOR_INVALID_MODEL;
+        throw new AdapterError(AdapterError.MEDIATOR_INVALID_MODEL);
     }
 
     if (!transaction) {
-        throw errors.MEDIATOR_INVALID_TXN;
+        throw new AdapterError(AdapterError.MEDIATOR_INVALID_TXN);
     }
 
     // save reference to model and transaction
@@ -75,7 +75,7 @@ util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
         // @todo perhaps tId could be passed on to waterline create via a direct param
         return id ? self._model.create(this._transaction.wrap(values), function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        }) : callback(errors.TRANSACTION_UNINITIATED);
+        }) : callback(new AdapterError(AdapterError.TRANSACTION_UNINITIATED));
     },
 
     update: function (criteria, values, callback) {
@@ -90,7 +90,7 @@ util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
         // @todo - is there no other way than injecting to values? what if pass direct to update?
         return id ? self._model.update(criteria, self._transaction.wrap(values), function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        }) : callback(errors.TRANSACTION_UNINITIATED);
+        }) : callback(new AdapterError(AdapterError.TRANSACTION_UNINITIATED));
     },
 
     // @todo - perhaps tId could be passed on to waterline destroy via a direct param
@@ -107,7 +107,7 @@ util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
         // do not need to separately treat callback and promise architecture.
         // @todo - check whether model.destroy returns any result. currently assumed not.
         return id ? self._model.destroy(self._transaction.wrap(criteria), callback) :
-            callback(errors.TRANSACTION_UNINITIATED);
+            callback(new AdapterError(AdapterError.TRANSACTION_UNINITIATED));
     },
 
     findOrCreate: function (criteria, values, callback) {
@@ -121,7 +121,7 @@ util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
         // in this case, the model's `findOrCreate` function accepts tId as a parameter.
         return id ? self._model.findOrCreate(criteria, values, function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        }, id) : callback(errors.TRANSACTION_UNINITIATED);
+        }, id) : callback(new AdapterError(AdapterError.TRANSACTION_UNINITIATED));
     },
 
     findOne: function (criteria, callback) {
@@ -135,7 +135,7 @@ util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
         // in this case, the model's `findOne` function accepts tId as a parameter.
         return id ? self._model.findOne(criteria, function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        }, id) : callback(errors.TRANSACTION_UNINITIATED);
+        }, id) : callback(new AdapterError(AdapterError.TRANSACTION_UNINITIATED));
     },
 
     // @todo trap when criteria is blank
@@ -162,7 +162,7 @@ util.extend(Mediator.prototype, /** @lends Mediator.prototype */ {
 
         return id ? self._model.find(criteria, options, function (err, result) {
             return callback(err, self._transaction.wrap(result));
-        }, id) : callback(errors.TRANSACTION_UNINITIATED);
+        }, id) : callback(new AdapterError(AdapterError.TRANSACTION_UNINITIATED));
     }
 });
 

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -1,5 +1,5 @@
 var util = require('./util'),
-    errors = require('./errors'),
+    AdapterError = require('./errors'),
     db = require('./db'),
     Transaction; // fn
 
@@ -23,7 +23,7 @@ Transaction = function (callback) {
         connect: function (callback) {
             // validate db setup prior to every connection. this ensures nothing goes forward post teardown
             if (!Transaction.db) {
-                callback(errors.TRANSACTION_NOT_SETUP);
+                callback(new AdapterError(AdapterError.TRANSACTION_NOT_SETUP));
             }
 
             if (!connection) {
@@ -143,7 +143,7 @@ util.extend(Transaction, /** @lends Transaction */ {
      */
     associateConnection: function (connection) {
         if (connection.transactionId && Transaction.connections[connection.transactionId]) {
-            throw errors.TRANSACTION_CONNECTION_OVERLAP;
+            throw new AdapterError(AdapterError.TRANSACTION_CONNECTION_OVERLAP);
         }
 
         connection.transactionId = util.uid();
@@ -262,7 +262,7 @@ util.extend(Transaction.prototype, /** @lends Transaction.prototype */ {
             // disassociate the connection from transaction and execute callback
             Transaction.disassociateConnection(conn);
             callback && callback(error);
-        }) : (callback && callback(errors.TRANSACTION_UNINITIATED_COMM));
+        }) : (callback && callback(new AdapterError(AdapterError.TRANSACTION_UNINITIATED_COMM)));
     },
 
     /**
@@ -291,7 +291,7 @@ util.extend(Transaction.prototype, /** @lends Transaction.prototype */ {
             // disassociate the connection from transaction and execute callback
             Transaction.disassociateConnection(conn);
             callback && callback(error);
-        }) : (callback && callback(errors.TRANSACTION_UNINITIATED_ROLL));
+        }) : (callback && callback(new AdapterError(AdapterError.TRANSACTION_UNINITIATED_ROLL)));
     },
 
     toString: function () {


### PR DESCRIPTION
This PR creates a custom Error object inherit called `AdapterError`. All errors thrown by the adapter is now initialised as new AdapterError