### PR TITLE
Family Planning (aka Selective Populates)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "lodash": "3.5.0",
     "mysql": "2.6.2",
-    "sails-mysql": "git+https://github.com/postmanlabs/sails-mysql.git#v0.10.12-postman.2"
+    "sails-mysql": "git+https://github.com/postmanlabs/sails-mysql.git#v0.10.12-postman.3"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/tests/integration/app/api/controllers/UserController.js
+++ b/tests/integration/app/api/controllers/UserController.js
@@ -141,7 +141,14 @@ module.exports = {
         }
 
         User.transact(transaction).findOne(users[0].id)
-          .populate('collections')
+          .populateSome({
+            collections: {
+              select: ['name']
+            },
+            teams: {
+              select: ['mascot', 'name']
+            }
+          })
           .exec(function (err, user) {
             if (err) {
               transaction.rollback();

--- a/tests/integration/app/api/models/Collection.js
+++ b/tests/integration/app/api/models/Collection.js
@@ -16,9 +16,17 @@ module.exports = {
     user: {
       model: 'User'
     },
+    fancy: {
+      type: 'boolean',
+      defaultsTo: false
+    },
     requests: {
       collection: 'Request',
       via: 'collection'
+    },
+    shared: {
+      type: 'boolean',
+      defaultsTo: false
     }
   },
 

--- a/tests/integration/app/api/models/Team.js
+++ b/tests/integration/app/api/models/Team.js
@@ -17,6 +17,9 @@ module.exports = {
     name: {
       type: 'string'
     },
+    mascot: {
+      type: 'string'
+    },
     members: {
       collection: 'User',
       via: 'teams',


### PR DESCRIPTION
This PR contains upgrades to sails-mysql fork and waterline. The upgrades are pertaining to feature and optimisation changes during query selection.

- Adds support to pass `select:[]` as part of criteria of `.populate`.
- Adds new function `.populateSome({ modelName: criteriaObject })`.